### PR TITLE
Add version hash to settings pane

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,6 +74,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: frontend
+          build-args: |
+            commit_hash=${GITHUB_SHA}
           push: ${{ env.PUSH }}
           tags: dzynetech/smart-ui:${{ env.TAG }}
         timeout-minutes: 240

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:16 as build
 
 WORKDIR /app
+ARG commit_hash
+ENV REACT_APP_COMMIT_HASH=${commit_hash}
 
 COPY ./react/package.json /app/package.json
 COPY ./react/package-lock.json /app/package-lock.json

--- a/frontend/react/src/components/Settings.tsx
+++ b/frontend/react/src/components/Settings.tsx
@@ -30,6 +30,7 @@ export default function Settings() {
           <label className="custom-control-label" htmlFor="autoplay"></label>
         </div>
       </Switch.Group>
+      {process.env.REACT_APP_COMMIT_HASH && <p className="text-sm mt-4 text-right text-gray-500 font-mono">Build {process.env.REACT_APP_COMMIT_HASH?.substring(0,8)}</p>}
     </>
   );
 }

--- a/production.yml
+++ b/production.yml
@@ -59,6 +59,8 @@ services:
   nginx:
     build: 
       context: ./frontend
+      args:
+        commit_hash: ${GITHUB_SHA}
     ports:
       - "$UI_PORT:80"
     depends_on:


### PR DESCRIPTION
fixes #38
uses `$GITHUB_SHA` to fill in version in github actions. Requires being manually set for a build with production.yml
